### PR TITLE
Modify installation steps for Japanese Dependency Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install -e .
 
 Note that, this environment only supports systems with CUDA. If you want to use PIXEL-M4, you need to install non-CUDA PyTorch packages with the same version numbers.
 
-### 3. Verify Installation on Japanese Dependency Parsing
+3. Verify Installation on Japanese Dependency Parsing
 
 ```bash
 # Create a folder in which we keep the data

--- a/README.md
+++ b/README.md
@@ -39,12 +39,16 @@ pip install -e .
 
 Note that, this environment only supports systems with CUDA. If you want to use PIXEL-M4, you need to install non-CUDA PyTorch packages with the same version numbers.
 
-3. Verify Installation on Japanese Dependency Parsing
+### 3. Verify Installation on Japanese Dependency Parsing
+
 ```bash
 # Create a folder in which we keep the data
 mkdir -p data
-# Get and extract the UD data for parsing and POS tagging
-wget -c https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11234/1-4758/ud-treebanks-v2.10.tgz
+
+# Download and extract the UD v2.10 treebanks
+curl -L -o ud-treebanks-v2.10.tgz \
+  "https://lindat.mff.cuni.cz/repository/server/api/core/bitstreams/handle/11234/1-4758/ud-treebanks-v2.10.tgz"
+
 tar xvf ud-treebanks-v2.10.tgz -C data
 
 # treebank, directories and hyperparameters


### PR DESCRIPTION
Updated installation instructions for Japanese Dependency Parsing to use the DSpace REST API endpoint.

The legacy `xmlui/bitstream` URL still works when accessed from a web browser, but automated tools (e.g. wget) now download an HTML page instead of the archive due to changes in the LINDAT/DSpace infrastructure.